### PR TITLE
Trim extra whitespace before search

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -134,7 +134,7 @@ export default function Home({ searchBoxOpen, setSearchBoxOpen, setAboutBoxOpen,
 					changeCurrentWord(wordArray[0]);
 				}
 			}
-			
+
 			// If the word isn't found, it adds the new word then switches to it
 			if (!wordFound) {
 				setLoading(true);
@@ -145,7 +145,7 @@ export default function Home({ searchBoxOpen, setSearchBoxOpen, setAboutBoxOpen,
 						const LatinHTML = ExtractLatinHTML(res.documentElement.outerHTML);
 						if (LatinHTML[1] === false) res = null;
 					}
-					
+
 					if (res === null && !isRedo) {
 						// word not found; resubmit with opposite capitalization
 						addWord(swapCapitalizations(word), true).then(status => {
@@ -177,14 +177,15 @@ export default function Home({ searchBoxOpen, setSearchBoxOpen, setAboutBoxOpen,
 			}
 		});
 	}
-	
+
 	window['addWord'] = addWord;
 
 	useEffect(() => {
 		if (searchBoxOpen !== true && searchBoxOpen !== false && searchBoxOpen !== '' && typeof searchBoxOpen === 'string') {
-			const words = searchBoxOpen.split(' ');
+			const words = searchBoxOpen.trim().split(' ');
 			words.forEach(word => {
-				window['addWord'](word);
+                if (word)
+					window['addWord'](word);
 			});
 		}
 	}, [searchBoxOpen]);


### PR DESCRIPTION
Presently, when searching if you have extra whitespace it will get included in the words split and will result in errors when attempting to search. I trimmed the whitespace as well as added a check to prevent attempts of searching for the empty string which was causing errors. 

(This is [basically the same change](https://github.com/sd0e/LatinLookup/pull/4) I made to the original LatinLookup in 2021)